### PR TITLE
Skip download if exportLinks doesn't exist.

### DIFF
--- a/drive.py
+++ b/drive.py
@@ -148,9 +148,9 @@ def download_file( service, drive_file, dest_path ):
 
     if is_google_doc(drive_file):
         try:
-          download_url = drive_file['exportLinks']['application/pdf']
+            download_url = drive_file['exportLinks']['application/pdf']
         except KeyError:
-          download_url = None
+            download_url = None
     else:
         download_url = drive_file['downloadUrl']
     if download_url:

--- a/drive.py
+++ b/drive.py
@@ -147,7 +147,10 @@ def download_file( service, drive_file, dest_path ):
     file_location = dest_path + drive_file['title'].replace( '/', '_' )
 
     if is_google_doc(drive_file):
-        download_url = drive_file['exportLinks']['application/pdf']
+        try:
+          download_url = drive_file['exportLinks']['application/pdf']
+        except KeyError:
+          download_url = None
     else:
         download_url = drive_file['downloadUrl']
     if download_url:


### PR DESCRIPTION
Google Forms don't have exportLinks so we'll just ignore those.